### PR TITLE
Revert "Add note about not needing this for Rails 5"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,4 @@ Usage
 Rails Versions
 ==============
 
-Tested on Rails 3.2, Rails 4.1.0.
-
-This gem is not needed on Rails 5.0 because an `ignored_columns` feature has
-been merged in https://github.com/rails/rails/pull/21720
+Tested on Rails 3.2, Rails 4.1.0. 


### PR DESCRIPTION
This small change from https://github.com/nthj/ignorable/pull/7 creates a merge conflict with changes from ztoolson.  Since I would like to keep those changes attributed to the original committers, I'm reverting here and will revert the revert once changes are merged.
